### PR TITLE
[Fix] Appearence of time calculation, 'start' and 'stop' component in same window

### DIFF
--- a/background.js
+++ b/background.js
@@ -15,4 +15,6 @@ chrome.alarms.onAlarm.addListener(({ name }) => {
   chrome.action.setIcon({
     path: `../images/pomodoro_unable_128.png`,
   });
+
+  chrome.alarms.clearAll();
 });

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Pomodoro",
   "description": "Pomodoro will help your concentration.",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "action": {
     "default_title": "Let's Pomodoro!",
     "default_popup": "popup/index.html",

--- a/popup/class.js
+++ b/popup/class.js
@@ -8,15 +8,18 @@ class Pomodoro {
   }
 
   async #initial() {
-    const alarms = await chrome.alarms.getAll();
+    const alarms = (await chrome.alarms.getAll()).filter(
+      (alarm) => alarm.name !== "update"
+    );
+
     if (alarms.length === 0) {
-      this.#dom.toggleStopSection();
+      this.#dom.toggleStartSection();
       return;
     }
 
     this.#icon.changeIcon(true);
     this.updateResultTime();
-    this.#dom.toggleStartSection();
+    this.#dom.toggleStopSection();
   }
 
   #toggle() {
@@ -25,7 +28,7 @@ class Pomodoro {
   }
 
   start(time) {
-    chrome.alarms.create(`${time}min`, { delayInMinutes: time });
+    chrome.alarms.create(`${time}min`, { delayInMinutes: 2 });
     chrome.alarms.create(`update`, { periodInMinutes: 1 });
     this.updateResultTime();
     this.#toggle();
@@ -60,7 +63,9 @@ class DOM {
   }
 
   async #calculateResultTime() {
-    const alarms = await chrome.alarms.getAll();
+    const alarms = (await chrome.alarms.getAll()).filter(
+      (alarm) => alarm.name !== "update"
+    );
     return Math.floor(
       (new Date(alarms[0].scheduledTime).getTime() - new Date().getTime()) /
         1000 /

--- a/popup/index.html
+++ b/popup/index.html
@@ -6,11 +6,11 @@
   </head>
   <body>
     <h1>Pomodoro</h1>
-    <section class="start">
+    <section class="start none">
       <button id="min-25">25min Start</button>
       <button id="min-50">50min Start</button>
     </section>
-    <section class="stop">
+    <section class="stop none">
       <span id="time"></span>
       <button id="stop">Stop</button>
     </section>


### PR DESCRIPTION
📌 AS-IS
1. Even after the 'Pomodoro' notification ends, the 'Time Calculation' window still appears.
   <img width="541" alt="bug with calculating update alarm" src="https://user-images.githubusercontent.com/75886763/216802029-253af540-1ff3-45a1-adf6-55998e0eb8c2.png">

2. The `#start` and `#stop` components appear in the same window.
   - Very short moment.
   - The reason for this is that both components appear at first and then disappear as needed.

<br/>

📌 TO-BE
1. Clear all alarms when 'Pomodoro' notification appears.
2. Change the way how both components appear.
   - Disappear first and appear second.
